### PR TITLE
ci: use java-docs-samples-testing for  native-image test

### DIFF
--- a/.kokoro/presubmit/graalvm-native.cfg
+++ b/.kokoro/presubmit/graalvm-native.cfg
@@ -14,20 +14,20 @@ env_vars: {
 # TODO: remove this after we've migrated all tests and scripts
 env_vars: {
   key: "GCLOUD_PROJECT"
-  value: "java-docs-samples-testing"
+  value: "gcloud-devel"
 }
 
 env_vars: {
   key: "GOOGLE_CLOUD_PROJECT"
-  value: "java-docs-samples-testing"
+  value: "gcloud-devel"
 }
 
 env_vars: {
   key: "GOOGLE_APPLICATION_CREDENTIALS"
-  value: "secret_manager/java-docs-samples-service-account"
+  value: "secret_manager/java-it-service-account"
 }
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "java-docs-samples-service-account"
+  value: "java-it-service-account"
 }

--- a/.kokoro/presubmit/graalvm-native.cfg
+++ b/.kokoro/presubmit/graalvm-native.cfg
@@ -14,20 +14,20 @@ env_vars: {
 # TODO: remove this after we've migrated all tests and scripts
 env_vars: {
   key: "GCLOUD_PROJECT"
-  value: "gcloud-devel"
+  value: "java-docs-samples-testing"
 }
 
 env_vars: {
   key: "GOOGLE_CLOUD_PROJECT"
-  value: "gcloud-devel"
+  value: "java-docs-samples-testing"
 }
 
 env_vars: {
   key: "GOOGLE_APPLICATION_CREDENTIALS"
-  value: "secret_manager/java-it-service-account"
+  value: "secret_manager/java-docs-samples-service-account"
 }
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "java-it-service-account"
+  value: "java-docs-samples-service-account"
 }

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ If you are using Maven, add this to your pom.xml file:
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-notebooks:1.0.3'
+implementation 'com.google.cloud:google-cloud-notebooks:1.0.4'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-notebooks" % "1.0.3"
+libraryDependencies += "com.google.cloud" % "google-cloud-notebooks" % "1.0.4"
 ```
 
 ## Authentication


### PR DESCRIPTION
Fixes https://github.com/googleapis/java-notebooks/issues/350

But integration.cfg still points to cloud-devrel and samples.cfg uses java-docs-samples.
